### PR TITLE
fix - new acessility errors

### DIFF
--- a/__tests__/src/components/styled/Language.test.tsx
+++ b/__tests__/src/components/styled/Language.test.tsx
@@ -9,11 +9,11 @@ import type { DefaultTheme } from 'styled-components'
 
 expect.extend(toHaveNoViolations)
 
-const renderLanguageComponent = (theme: DefaultTheme) => {
+const renderLanguageComponent = (theme: DefaultTheme, isVisible = false) => {
   return render(
     <Language.Select aria-label="Language selection">
       <Language.Button>Select language</Language.Button>
-      <Language.Popover aria-label="Language popover">
+      <Language.Popover aria-label="Language popover" isVisible={isVisible}>
         <ListBox aria-label="List of languages">
           <Language.ListBoxItem id="pt-BR">PT</Language.ListBoxItem>
           <Language.ListBoxItem id="en">EN</Language.ListBoxItem>
@@ -85,7 +85,7 @@ describe('Language Component', () => {
   ])(
     'should apply correct styles to PopoverStyled with %s theme',
     (_, theme) => {
-      renderLanguageComponent(theme)
+      renderLanguageComponent(theme, true)
 
       const selectButton = screen.getByRole('button', {
         name: /language selection/i,

--- a/src/components/LanguageSelect.tsx
+++ b/src/components/LanguageSelect.tsx
@@ -1,9 +1,9 @@
 import { Language } from '@components/styled/Language'
 import { useAppStore } from '@store/app'
 import { ChevronDown } from 'lucide-react'
+import { useState } from 'react'
 import { type Key, ListBox, SelectValue } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
-import { useState } from 'react'
 
 export const LanguageSelect = () => {
   const { setLocale } = useAppStore()

--- a/src/components/LanguageSelect.tsx
+++ b/src/components/LanguageSelect.tsx
@@ -3,32 +3,44 @@ import { useAppStore } from '@store/app'
 import { ChevronDown } from 'lucide-react'
 import { type Key, ListBox, SelectValue } from 'react-aria-components'
 import { useTranslation } from 'react-i18next'
+import { useState } from 'react'
 
 export const LanguageSelect = () => {
   const { setLocale } = useAppStore()
   const {
     i18n: { language, changeLanguage },
   } = useTranslation()
+
+  const [isVisible, setIsVisible] = useState(false)
+
   const onSelectionChange = (lang: Key) => {
     if (typeof lang === 'string') {
       setLocale(lang as 'pt-BR' | 'en')
       changeLanguage(lang)
     }
   }
+
   return (
     <Language.Select
       aria-label="language select"
       selectedKey={language}
       onSelectionChange={onSelectionChange}
+      onFocus={() => setIsVisible(true)}
+      onBlur={() => setIsVisible(false)}
     >
       <Language.Button>
         <SelectValue />
         <ChevronDown />
       </Language.Button>
-      <Language.Popover>
+
+      <Language.Popover aria-hidden={!isVisible} isVisible={isVisible}>
         <ListBox>
-          <Language.ListBoxItem id="pt-BR">PT</Language.ListBoxItem>
-          <Language.ListBoxItem id="en">EN</Language.ListBoxItem>
+          <Language.ListBoxItem id="pt-BR" aria-hidden={!isVisible}>
+            PT
+          </Language.ListBoxItem>
+          <Language.ListBoxItem id="en" aria-hidden={!isVisible}>
+            EN
+          </Language.ListBoxItem>
         </ListBox>
       </Language.Popover>
     </Language.Select>

--- a/src/components/styled/Language.ts
+++ b/src/components/styled/Language.ts
@@ -30,7 +30,7 @@ const ButtonStyled = styled(Button)`
   }
 `
 
-const PopoverStyled = styled(Popover)`
+const PopoverStyled = styled(Popover)<{ isVisible: boolean }>`
   position: absolute;
   z-index: 1;
   min-width: 52px;
@@ -40,6 +40,12 @@ const PopoverStyled = styled(Popover)`
   border-radius: 0.375rem;
   box-shadow: ${({ theme }) => theme.boxShadow};
   margin-top: 0.5rem;
+
+  display: ${({ isVisible }) => (isVisible ? 'block' : 'none')};
+
+  &[data-hidden="true"] {
+    display: none;
+  }
 `
 
 const ListBoxItemStyled = styled(ListBoxItem)`

--- a/src/pages/home/Homepage.tsx
+++ b/src/pages/home/Homepage.tsx
@@ -55,9 +55,10 @@ export const Homepage = () => {
             id="view-toggle"
             isSelected={isCardView}
             onChange={setIsCardView}
-            aria-label="toggle table button"
+            aria-labelledby="view-toggle-label"
+            aria-label="toggle table label"
           >
-            <Label htmlFor="view-toggle" aria-label="toggle table label">
+            <Label id="view-toggle-label" htmlFor="view-toggle">
               {isCardView ? t('homepage.cardView') : t('homepage.tableView')}
             </Label>
           </Switch>


### PR DESCRIPTION
# Descrição do PR

Este PR resolve dois problemas de acessibilidade e ajusta a formatação do código para seguir as regras de lint.

## Alterações principais:
- **Correções de acessibilidade**:
  - Elementos com `aria-hidden` não são mais focáveis.
  - O texto visível agora faz parte do nome acessível, garantindo que elementos interativos estejam em conformidade com as melhores práticas de acessibilidade.
  
- **Ajustes de formatação (Lint)**:
  - O import de `useState` foi reposicionado para seguir a formatação correta conforme as regras de linting.

---

### Commits relevantes:
- `fix: errors on accessibility`
- `fix(LanguageSelect.tsx): lint format useState import position`
